### PR TITLE
gcc-wrapper: point shebang to python3

### DIFF
--- a/scripts/gcc-wrapper.py
+++ b/scripts/gcc-wrapper.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2011-2012, The Linux Foundation. All rights reserved.


### PR DESCRIPTION
The python command needs to point to python3 to build.

There are several ways to archive that. Example:

```
sudo apt install python-is-python3
```